### PR TITLE
Improve channel handling in deployCDK

### DIFF
--- a/vars/deployCDK.groovy
+++ b/vars/deployCDK.groovy
@@ -20,7 +20,7 @@ def call(Map conf) {
         conf.bundle_channel = 'edge'
     }
     if (!conf.charms_channel) {
-        conf.charms_channel = ""  // is this needed?  will we get a "null" without it?
+        conf.charms_channel = ""  // prevent "null" in command
     } else {
         conf.charms_channel = "--channel ${conf.charms_channel}"
     }

--- a/vars/deployCDK.groovy
+++ b/vars/deployCDK.groovy
@@ -6,6 +6,8 @@
  *    conf.cloud juju cloud in a cloud/region format
  *    conf.version_overlay path to bundle overlay for defining k8s versions
  *    conf.bundle_channel juju charmstore channel to pull bundle from
+ *                        (note: this only affects the channel of the bundle)
+ *    conf.charms_channel juju charmstore channel to force all charms within the bundle to
  *    conf.allow_privileged enable allow privileged in k8s master/worker
  *    conf.disable_add_model do not run add-model, this is due to factors such
  *                           as localhost that need lxd profiles update prior to deploy
@@ -17,6 +19,11 @@ def call(Map conf) {
     if (!conf.bundle_channel) {
         conf.bundle_channel = 'edge'
     }
+    if (!conf.charms_channel) {
+        conf.charms_channel = ""  // is this needed?  will we get a "null" without it?
+    } else {
+        conf.charms_channel = "--channel ${conf.charms_channel}"
+    }
     if (!conf.allow_privileged) {
         conf.allow_privileged = false
     }
@@ -27,7 +34,11 @@ def call(Map conf) {
             sh "juju add-model -c ${conf.controller} ${conf.model}"
         }
     }
-    sh "juju deploy -m ${conf.controller}:${conf.model} ${conf.bundle} --overlay ${conf.version_overlay} --channel ${conf.bundle_channel}"
+    // There is no way to tell Juju to use a specific channel of a bundle but
+    // to leave the contents unmodified, so we have to pull a local copy of the
+    // channel that we want.
+    sh "charm pull ${conf.bundle} --channel ${conf.bundle_channel} ./bundle-to-test"
+    sh "juju deploy -m ${conf.controller}:${conf.model} ./bundle-to-test/bundle.yaml --overlay ${conf.version_overlay} ${conf.charms_channel}"
     if (conf.allow_privileged) {
         sh "juju config -m ${conf.controller}:${conf.model} kubernetes-master allow-privileged=true"
         sh "juju config -m ${conf.controller}:${conf.model} kubernetes-worker allow-privileged=true"


### PR DESCRIPTION
Juju's handling of channels for bundles is strange. There is no way to tell it to use a specific channel for a bundle without also forcing all of the charms within the bundle to that same channel.

This refactors the `bundle_channel` param to be two separate params:

* `bundle_channel` Only influences the channel of the bundle itself
* `charms_channel` Forces the channel of all charms in the bundle

This is specifically needed for the Vault tests because the edge channel of the Vault charm is not available. (See [build #11](https://jenkins.canonical.com/k8s/job/validate-vault-v1.12.x/11/console))